### PR TITLE
feat: add JPA entities to query database tables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ yarn-error.log
 .history/*
 
 # Miscellaneous
-/.angular/cache
+task-flow/.angular/
 .sass-cache/
 /connect.lock
 /coverage

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>23</java.version>
+		<java.version>21</java.version>
 		<liquibase.version>4.31.1</liquibase.version>
 		<postgresql.version>42.7.5</postgresql.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
 		<java.version>21</java.version>
 		<liquibase.version>4.31.1</liquibase.version>
 		<postgresql.version>42.7.5</postgresql.version>
+		<hikari.version>6.3.0</hikari.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -59,18 +60,23 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
 			<version>${liquibase.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<version>${postgresql.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<version>${hikari.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/io/robeel/bhatti/taskFlow/configuration/DatabaseConfiguration.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/configuration/DatabaseConfiguration.java
@@ -1,0 +1,11 @@
+package io.robeel.bhatti.taskFlow.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableJpaRepositories(basePackages = "io.robeel.bhatti.taskFlow.repository")
+@EnableTransactionManagement
+public class DatabaseConfiguration {
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Address.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Address.java
@@ -1,21 +1,18 @@
 package io.robeel.bhatti.taskFlow.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.time.Instant;
 
 @Getter
 @Setter
 @Entity
 @Table(name = "addresses", schema = "task_flow")
 public class Address {
+
     @Id
-    @Column(name = "id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
 
     @Column(name = "street", nullable = false, length = 256)
@@ -32,17 +29,4 @@ public class Address {
 
     @Column(name = "state", nullable = false, length = 2)
     private String state;
-
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
-    @Column(name = "modified_at", nullable = false)
-    private Instant modifiedAt;
-
-    @Column(name = "created_by", nullable = false, length = 256)
-    private String createdBy;
-
-    @Column(name = "modified_by", nullable = false, length = 256)
-    private String modifiedBy;
-
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Address.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Address.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Address {
+  }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Address.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Address.java
@@ -1,7 +1,48 @@
 package io.robeel.bhatti.taskFlow.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
 
+import java.time.Instant;
+
+@Getter
+@Setter
 @Entity
+@Table(name = "addresses", schema = "task_flow")
 public class Address {
-  }
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "street", nullable = false, length = 256)
+    private String street;
+
+    @Column(name = "country", nullable = false, length = 3)
+    private String country;
+
+    @Column(name = "zip", nullable = false, length = 10)
+    private String zip;
+
+    @Column(name = "city", nullable = false, length = 256)
+    private String city;
+
+    @Column(name = "state", nullable = false, length = 2)
+    private String state;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+
+    @Column(name = "created_by", nullable = false, length = 256)
+    private String createdBy;
+
+    @Column(name = "modified_by", nullable = false, length = 256)
+    private String modifiedBy;
+
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Address.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Address.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 @Entity
 @Table(name = "addresses", schema = "task_flow")
-public class Address {
+public class Address extends Auditable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Auditable.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Auditable.java
@@ -1,0 +1,23 @@
+package io.robeel.bhatti.taskFlow.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+
+import java.time.Instant;
+
+@MappedSuperclass
+public class Auditable {
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+
+    @Column(name = "created_by", nullable = false, length = 256)
+    private String createdBy;
+
+    @Column(name = "modified_by", nullable = false, length = 256)
+    private String modifiedBy;
+
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Auditable.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Auditable.java
@@ -2,21 +2,29 @@ package io.robeel.bhatti.taskFlow.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.Instant;
 
 @MappedSuperclass
 public class Auditable {
 
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
+    @LastModifiedDate
     @Column(name = "modified_at", nullable = false)
     private Instant modifiedAt;
 
+    @CreatedBy
     @Column(name = "created_by", nullable = false, length = 256)
     private String createdBy;
 
+    @LastModifiedBy
     @Column(name = "modified_by", nullable = false, length = 256)
     private String modifiedBy;
 

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Category.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Category.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Category {
+  }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Category.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Category.java
@@ -1,7 +1,36 @@
 package io.robeel.bhatti.taskFlow.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
 
+import java.time.Instant;
+
+@Getter
+@Setter
 @Entity
+@Table(name = "categories", schema = "task_flow")
 public class Category {
-  }
+    @Id
+    @Column(name = "category", nullable = false, length = 20)
+    private String category;
+
+    @Column(name = "description", nullable = false, length = 256)
+    private String description;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+
+    @Column(name = "created_by", nullable = false, length = 256)
+    private String createdBy;
+
+    @Column(name = "modified_by", nullable = false, length = 256)
+    private String modifiedBy;
+
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Category.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Category.java
@@ -7,13 +7,11 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.Instant;
-
 @Getter
 @Setter
 @Entity
 @Table(name = "categories", schema = "task_flow")
-public class Category {
+public class Category extends Auditable {
 
     @Id
     @Column(name = "category", nullable = false, length = 20)
@@ -21,17 +19,5 @@ public class Category {
 
     @Column(name = "description", nullable = false, length = 256)
     private String description;
-
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
-    @Column(name = "modified_at", nullable = false)
-    private Instant modifiedAt;
-
-    @Column(name = "created_by", nullable = false, length = 256)
-    private String createdBy;
-
-    @Column(name = "modified_by", nullable = false, length = 256)
-    private String modifiedBy;
 
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Category.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Category.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 @Entity
 @Table(name = "categories", schema = "task_flow")
 public class Category {
+
     @Id
     @Column(name = "category", nullable = false, length = 20)
     private String category;

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Employee.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Employee.java
@@ -1,7 +1,49 @@
 package io.robeel.bhatti.taskFlow.domain;
 
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 
+import java.time.Instant;
+
+@Getter
+@Setter
 @Entity
+@Table(name = "employees", schema = "task_flow")
 public class Employee {
-  }
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 256)
+    private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "address_id", nullable = false)
+    private Address address;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manager_id")
+    private Employee manager;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "title", nullable = false)
+    private io.robeel.bhatti.taskFlow.domain.Title title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team")
+    private io.robeel.bhatti.taskFlow.domain.Team team;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+
+    @Column(name = "created_by", nullable = false, length = 256)
+    private String createdBy;
+
+    @Column(name = "modified_by", nullable = false, length = 256)
+    private String modifiedBy;
+
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Employee.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Employee.java
@@ -18,20 +18,16 @@ public class Employee extends Auditable {
     @Column(name = "name", nullable = false, length = 256)
     private String name;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "address_id", nullable = false)
-    private Address address;
+    @Column(name = "address_id", nullable = false)
+    private Long addressId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "manager_id")
-    private Employee manager;
+    @Column(name = "manager_id")
+    private Long managerId;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "title", nullable = false)
-    private Title title;
+    @Column(name = "title", nullable = false)
+    private String title;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team")
-    private Team team;
+    @Column(name = "team")
+    private String team;
 
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Employee.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Employee.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Employee {
+  }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Employee.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Employee.java
@@ -4,13 +4,11 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.Instant;
-
 @Getter
 @Setter
 @Entity
 @Table(name = "employees", schema = "task_flow")
-public class Employee {
+public class Employee extends Auditable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,17 +33,5 @@ public class Employee {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team")
     private Team team;
-
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
-    @Column(name = "modified_at", nullable = false)
-    private Instant modifiedAt;
-
-    @Column(name = "created_by", nullable = false, length = 256)
-    private String createdBy;
-
-    @Column(name = "modified_by", nullable = false, length = 256)
-    private String modifiedBy;
 
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Employee.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Employee.java
@@ -11,7 +11,9 @@ import java.time.Instant;
 @Entity
 @Table(name = "employees", schema = "task_flow")
 public class Employee {
+
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
     private Long id;
 
@@ -28,11 +30,11 @@ public class Employee {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "title", nullable = false)
-    private io.robeel.bhatti.taskFlow.domain.Title title;
+    private Title title;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team")
-    private io.robeel.bhatti.taskFlow.domain.Team team;
+    private Team team;
 
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Priority.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Priority.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Priority {
+  }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Priority.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Priority.java
@@ -7,13 +7,11 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.Instant;
-
 @Getter
 @Setter
 @Entity
 @Table(name = "priorities", schema = "task_flow")
-public class Priority {
+public class Priority extends Auditable {
 
     @Id
     @Column(name = "priority", nullable = false, length = 20)
@@ -21,17 +19,5 @@ public class Priority {
 
     @Column(name = "description", nullable = false, length = 256)
     private String description;
-
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
-    @Column(name = "modified_at", nullable = false)
-    private Instant modifiedAt;
-
-    @Column(name = "created_by", nullable = false, length = 256)
-    private String createdBy;
-
-    @Column(name = "modified_by", nullable = false, length = 256)
-    private String modifiedBy;
 
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Priority.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Priority.java
@@ -1,7 +1,36 @@
 package io.robeel.bhatti.taskFlow.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
 
+import java.time.Instant;
+
+@Getter
+@Setter
 @Entity
+@Table(name = "priorities", schema = "task_flow")
 public class Priority {
-  }
+    @Id
+    @Column(name = "priority", nullable = false, length = 20)
+    private String priority;
+
+    @Column(name = "description", nullable = false, length = 256)
+    private String description;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+
+    @Column(name = "created_by", nullable = false, length = 256)
+    private String createdBy;
+
+    @Column(name = "modified_by", nullable = false, length = 256)
+    private String modifiedBy;
+
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Priority.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Priority.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 @Entity
 @Table(name = "priorities", schema = "task_flow")
 public class Priority {
+
     @Id
     @Column(name = "priority", nullable = false, length = 20)
     private String priority;

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Project.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Project.java
@@ -4,14 +4,13 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.Instant;
 import java.time.LocalDate;
 
 @Getter
 @Setter
 @Entity
 @Table(name = "projects", schema = "task_flow")
-public class Project {
+public class Project extends Auditable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,18 +38,6 @@ public class Project {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category")
     private Category category;
-
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
-    @Column(name = "modified_at", nullable = false)
-    private Instant modifiedAt;
-
-    @Column(name = "created_by", nullable = false, length = 256)
-    private String createdBy;
-
-    @Column(name = "modified_by", nullable = false, length = 256)
-    private String modifiedBy;
 
     @Column(name = "started_at")
     private LocalDate startedAt;

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Project.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Project.java
@@ -12,7 +12,9 @@ import java.time.LocalDate;
 @Entity
 @Table(name = "projects", schema = "task_flow")
 public class Project {
+
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
     private Long id;
 
@@ -24,7 +26,7 @@ public class Project {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team")
-    private io.robeel.bhatti.taskFlow.domain.Team team;
+    private Team team;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "priority")
@@ -32,7 +34,7 @@ public class Project {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "status")
-    private io.robeel.bhatti.taskFlow.domain.Status status;
+    private Status status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category")

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Project.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Project.java
@@ -23,21 +23,17 @@ public class Project extends Auditable {
     @Column(name = "description", length = 256)
     private String description;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team")
-    private Team team;
+    @Column(name = "team")
+    private String team;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "priority")
-    private Priority priority;
+    @Column(name = "priority")
+    private String priority;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "status")
-    private Status status;
+    @Column(name = "status")
+    private String status;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category")
-    private Category category;
+    @Column(name = "category")
+    private String category;
 
     @Column(name = "started_at")
     private LocalDate startedAt;

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Project.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Project.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Project {
+  }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Project.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Project.java
@@ -1,7 +1,61 @@
 package io.robeel.bhatti.taskFlow.domain;
 
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Getter
+@Setter
 @Entity
+@Table(name = "projects", schema = "task_flow")
 public class Project {
-  }
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 256)
+    private String name;
+
+    @Column(name = "description", length = 256)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team")
+    private io.robeel.bhatti.taskFlow.domain.Team team;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "priority")
+    private Priority priority;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "status")
+    private io.robeel.bhatti.taskFlow.domain.Status status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category")
+    private Category category;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+
+    @Column(name = "created_by", nullable = false, length = 256)
+    private String createdBy;
+
+    @Column(name = "modified_by", nullable = false, length = 256)
+    private String modifiedBy;
+
+    @Column(name = "started_at")
+    private LocalDate startedAt;
+
+    @Column(name = "completed_at")
+    private LocalDate completedAt;
+
+    @Column(name = "due_at", nullable = false)
+    private LocalDate dueAt;
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Status.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Status.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Status {
+  }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Status.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Status.java
@@ -1,7 +1,36 @@
 package io.robeel.bhatti.taskFlow.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
 
+import java.time.Instant;
+
+@Getter
+@Setter
 @Entity
+@Table(name = "statuses", schema = "task_flow")
 public class Status {
-  }
+    @Id
+    @Column(name = "status", nullable = false, length = 20)
+    private String status;
+
+    @Column(name = "description", nullable = false, length = 256)
+    private String description;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+
+    @Column(name = "created_by", nullable = false, length = 256)
+    private String createdBy;
+
+    @Column(name = "modified_by", nullable = false, length = 256)
+    private String modifiedBy;
+
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Status.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Status.java
@@ -7,13 +7,11 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.Instant;
-
 @Getter
 @Setter
 @Entity
 @Table(name = "statuses", schema = "task_flow")
-public class Status {
+public class Status extends Auditable {
 
     @Id
     @Column(name = "status", nullable = false, length = 20)
@@ -21,17 +19,5 @@ public class Status {
 
     @Column(name = "description", nullable = false, length = 256)
     private String description;
-
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
-    @Column(name = "modified_at", nullable = false)
-    private Instant modifiedAt;
-
-    @Column(name = "created_by", nullable = false, length = 256)
-    private String createdBy;
-
-    @Column(name = "modified_by", nullable = false, length = 256)
-    private String modifiedBy;
 
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Status.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Status.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 @Entity
 @Table(name = "statuses", schema = "task_flow")
 public class Status {
+
     @Id
     @Column(name = "status", nullable = false, length = 20)
     private String status;

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Task.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Task.java
@@ -23,21 +23,17 @@ public class Task extends Auditable {
     @Column(name = "description", nullable = false, length = 256)
     private String description;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "project_id", nullable = false)
-    private Project project;
+    @Column(name = "project_id", nullable = false)
+    private Long projectId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "priority")
-    private Priority priority;
+    @Column(name = "priority")
+    private String priority;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "status")
-    private Status status;
+    @Column(name = "status")
+    private String status;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "employee_id")
-    private Employee employee;
+    @Column(name = "employee_id")
+    private Long employeeId;
 
     @Column(name = "due_at", nullable = false)
     private LocalDate dueAt;

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Task.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Task.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Task {
+  }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Task.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Task.java
@@ -4,14 +4,13 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.Instant;
 import java.time.LocalDate;
 
 @Getter
 @Setter
 @Entity
 @Table(name = "tasks", schema = "task_flow")
-public class Task {
+public class Task extends Auditable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -45,17 +44,4 @@ public class Task {
 
     @Column(name = "completed_at")
     private LocalDate completedAt;
-
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
-    @Column(name = "modified_at", nullable = false)
-    private Instant modifiedAt;
-
-    @Column(name = "created_by", nullable = false, length = 256)
-    private String createdBy;
-
-    @Column(name = "modified_by", nullable = false, length = 256)
-    private String modifiedBy;
-
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Task.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Task.java
@@ -12,7 +12,9 @@ import java.time.LocalDate;
 @Entity
 @Table(name = "tasks", schema = "task_flow")
 public class Task {
+
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
     private Long id;
 

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Task.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Task.java
@@ -1,7 +1,59 @@
 package io.robeel.bhatti.taskFlow.domain;
 
-import jakarta.persistence.Entity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Getter
+@Setter
 @Entity
+@Table(name = "tasks", schema = "task_flow")
 public class Task {
-  }
+    @Id
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 256)
+    private String name;
+
+    @Column(name = "description", nullable = false, length = 256)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "priority")
+    private Priority priority;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "status")
+    private Status status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "employee_id")
+    private Employee employee;
+
+    @Column(name = "due_at", nullable = false)
+    private LocalDate dueAt;
+
+    @Column(name = "completed_at")
+    private LocalDate completedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+
+    @Column(name = "created_by", nullable = false, length = 256)
+    private String createdBy;
+
+    @Column(name = "modified_by", nullable = false, length = 256)
+    private String modifiedBy;
+
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Team.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Team.java
@@ -1,7 +1,36 @@
 package io.robeel.bhatti.taskFlow.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
 
+import java.time.Instant;
+
+@Getter
+@Setter
 @Entity
+@Table(name = "teams", schema = "task_flow")
 public class Team {
-  }
+    @Id
+    @Column(name = "team", nullable = false, length = 20)
+    private String team;
+
+    @Column(name = "description", nullable = false, length = 256)
+    private String description;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+
+    @Column(name = "created_by", nullable = false, length = 256)
+    private String createdBy;
+
+    @Column(name = "modified_by", nullable = false, length = 256)
+    private String modifiedBy;
+
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Team.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Team.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 @Entity
 @Table(name = "teams", schema = "task_flow")
 public class Team {
+
     @Id
     @Column(name = "team", nullable = false, length = 20)
     private String team;

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Team.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Team.java
@@ -7,13 +7,11 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.Instant;
-
 @Getter
 @Setter
 @Entity
 @Table(name = "teams", schema = "task_flow")
-public class Team {
+public class Team extends Auditable {
 
     @Id
     @Column(name = "team", nullable = false, length = 20)
@@ -21,17 +19,5 @@ public class Team {
 
     @Column(name = "description", nullable = false, length = 256)
     private String description;
-
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
-    @Column(name = "modified_at", nullable = false)
-    private Instant modifiedAt;
-
-    @Column(name = "created_by", nullable = false, length = 256)
-    private String createdBy;
-
-    @Column(name = "modified_by", nullable = false, length = 256)
-    private String modifiedBy;
 
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Team.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Team.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Team {
+  }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Title.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Title.java
@@ -1,7 +1,36 @@
 package io.robeel.bhatti.taskFlow.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
 
+import java.time.Instant;
+
+@Getter
+@Setter
 @Entity
+@Table(name = "titles", schema = "task_flow")
 public class Title {
-  }
+    @Id
+    @Column(name = "title", nullable = false, length = 20)
+    private String title;
+
+    @Column(name = "description", nullable = false, length = 256)
+    private String description;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private Instant modifiedAt;
+
+    @Column(name = "created_by", nullable = false, length = 256)
+    private String createdBy;
+
+    @Column(name = "modified_by", nullable = false, length = 256)
+    private String modifiedBy;
+
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Title.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Title.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.domain;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public class Title {
+  }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Title.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Title.java
@@ -7,13 +7,11 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.Instant;
-
 @Getter
 @Setter
 @Entity
 @Table(name = "titles", schema = "task_flow")
-public class Title {
+public class Title extends Auditable {
 
     @Id
     @Column(name = "title", nullable = false, length = 20)
@@ -21,17 +19,5 @@ public class Title {
 
     @Column(name = "description", nullable = false, length = 256)
     private String description;
-
-    @Column(name = "created_at", nullable = false)
-    private Instant createdAt;
-
-    @Column(name = "modified_at", nullable = false)
-    private Instant modifiedAt;
-
-    @Column(name = "created_by", nullable = false, length = 256)
-    private String createdBy;
-
-    @Column(name = "modified_by", nullable = false, length = 256)
-    private String modifiedBy;
 
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/domain/Title.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/domain/Title.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 @Entity
 @Table(name = "titles", schema = "task_flow")
 public class Title {
+
     @Id
     @Column(name = "title", nullable = false, length = 20)
     private String title;

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/AddressRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/AddressRepository.java
@@ -2,6 +2,8 @@ package io.robeel.bhatti.taskFlow.repository;
 
 import io.robeel.bhatti.taskFlow.domain.Address;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface AddressRepository extends JpaRepository<Address, Long> {
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/AddressRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/AddressRepository.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.repository;
+
+import io.robeel.bhatti.taskFlow.domain.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/CategoryRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/CategoryRepository.java
@@ -2,6 +2,8 @@ package io.robeel.bhatti.taskFlow.repository;
 
 import io.robeel.bhatti.taskFlow.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CategoryRepository extends JpaRepository<Category, String> {
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/CategoryRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.repository;
+
+import io.robeel.bhatti.taskFlow.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, String> {
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/EmployeeRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/EmployeeRepository.java
@@ -2,6 +2,8 @@ package io.robeel.bhatti.taskFlow.repository;
 
 import io.robeel.bhatti.taskFlow.domain.Employee;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface EmployeeRepository extends JpaRepository<Employee, Long> {
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/EmployeeRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/EmployeeRepository.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.repository;
+
+import io.robeel.bhatti.taskFlow.domain.Employee;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmployeeRepository extends JpaRepository<Employee, Long> {
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/PriorityRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/PriorityRepository.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.repository;
+
+import io.robeel.bhatti.taskFlow.domain.Priority;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PriorityRepository extends JpaRepository<Priority, String> {
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/PriorityRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/PriorityRepository.java
@@ -2,6 +2,8 @@ package io.robeel.bhatti.taskFlow.repository;
 
 import io.robeel.bhatti.taskFlow.domain.Priority;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface PriorityRepository extends JpaRepository<Priority, String> {
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/ProjectRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/ProjectRepository.java
@@ -2,6 +2,8 @@ package io.robeel.bhatti.taskFlow.repository;
 
 import io.robeel.bhatti.taskFlow.domain.Project;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/ProjectRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.repository;
+
+import io.robeel.bhatti.taskFlow.domain.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/StatusRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/StatusRepository.java
@@ -2,6 +2,8 @@ package io.robeel.bhatti.taskFlow.repository;
 
 import io.robeel.bhatti.taskFlow.domain.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface StatusRepository extends JpaRepository<Status, String> {
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/StatusRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/StatusRepository.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.repository;
+
+import io.robeel.bhatti.taskFlow.domain.Status;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StatusRepository extends JpaRepository<Status, String> {
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/TaskRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/TaskRepository.java
@@ -2,6 +2,8 @@ package io.robeel.bhatti.taskFlow.repository;
 
 import io.robeel.bhatti.taskFlow.domain.Task;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface TaskRepository extends JpaRepository<Task, Long> {
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/TaskRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/TaskRepository.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.repository;
+
+import io.robeel.bhatti.taskFlow.domain.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/TeamRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/TeamRepository.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.repository;
+
+import io.robeel.bhatti.taskFlow.domain.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, String> {
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/TeamRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/TeamRepository.java
@@ -2,6 +2,8 @@ package io.robeel.bhatti.taskFlow.repository;
 
 import io.robeel.bhatti.taskFlow.domain.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface TeamRepository extends JpaRepository<Team, String> {
 }

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/TitleRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/TitleRepository.java
@@ -1,0 +1,7 @@
+package io.robeel.bhatti.taskFlow.repository;
+
+import io.robeel.bhatti.taskFlow.domain.Title;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TitleRepository extends JpaRepository<Title, String> {
+}

--- a/src/main/java/io/robeel/bhatti/taskFlow/repository/TitleRepository.java
+++ b/src/main/java/io/robeel/bhatti/taskFlow/repository/TitleRepository.java
@@ -2,6 +2,8 @@ package io.robeel.bhatti.taskFlow.repository;
 
 import io.robeel.bhatti.taskFlow.domain.Title;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface TitleRepository extends JpaRepository<Title, String> {
 }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,3 @@
 databaseChangeLog:
   - includeAll:
       path: /db/changelog/changelog-tables/
-  - includeAll:
-      path: /db/changelog/data/


### PR DESCRIPTION
Add JPA entities and JPA repositories to perform CRUD queries against the database. This is a basic implementation of the data access layer and will be iterated on as the project grows. 

Audit-level data will most likely be taken from the JWT in the request and automatically mapped to the JPA fields due to the Spring JPA audit annotations in the `Auditable.java` entity. 